### PR TITLE
Feature/ccaas service

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,14 +24,15 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Build image
+      - name: Build Docker image
         run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
 
       - name: Log in to registry
         # This is where you will update the PAT to GITHUB_TOKEN
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Push image
+      - name: Publish Docker image
+        if: github.event_name != 'pull_request'
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
           # Change all uppercase to lowercase

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  IMAGE_NAME: fabric-builder-k8s
+
 jobs:
 
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,14 +14,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build Docker image
-      run: docker build . --file Dockerfile --tag ghcr.io/hyperledgendary/k8s-fabric-peer:${GITHUB_SHA}
-    - name: Publish Docker image
-      if: github.event_name != 'pull_request'
-      run: |
-        echo ${DOCKER_PW} | docker login ghcr.io -u ${DOCKER_USER} --password-stdin
-        docker push ghcr.io/hyperledgendary/k8s-fabric-peer:${GITHUB_SHA}
-      env:
-        DOCKER_USER: ${{ github.actor }}
-        DOCKER_PW: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v3
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log in to registry
+        # This is where you will update the PAT to GITHUB_TOKEN
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,6 +16,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      packages: write
+      contents: read
+
     steps:
 
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+.idea/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The k8s chaincode package contains an image name and tag.
 For example, to create a basic k8s chaincode package using the `pkgk8scc.sh` helper script.
 
 ```shell
-pkgk8scc.sh -l sample -n ghcr.io/hyperledger/asset-transfer-basic -t 1.0
+pkgk8scc.sh -l sample -n ghcr.io/hyperledgendary/fabric-ccaas-asset-transfer-basic -t latest
 ```
 
 You can also create the same chaincode package manually.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ peer lifecycle chaincode install sample.tgz
 ```shell
 export PACKAGE_ID=sample:...
 ```
+or 
+```shell
+export PACKAGE_ID=sample:$(shasum -a 256 sample.tgz  | tr -s ' ' | cut -d ' ' -f 1)
+```
 
 Approve the chaincode
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Set up a [k8s test network](https://github.com/hyperledger/fabric-samples/tree/m
         path: /var/hyperledger/fabric/external_builders/k8s_builder
         propagateEnvironment:
           - CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG
+          - KUBERNETES_SERVICE_HOST
+          - KUBERNETES_SERVICE_PORT
 ```
 2. `network kind`
 3. `network up && network channel create`

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,0 +1,7 @@
+# Adds namespace to all resources.
+namespace: test-network
+
+bases:
+  - ../rbac
+  - ../jobs
+

--- a/config/jobs/kustomization.yaml
+++ b/config/jobs/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - org1-deploy-builder-job.yaml
+  - org2-deploy-builder-job.yaml

--- a/config/jobs/org1-deploy-builder-job.yaml
+++ b/config/jobs/org1-deploy-builder-job.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: org1-deploy-k8s-builder-job
+spec:
+  backoffLimit: 0
+  completions: 1
+  template:
+    metadata:
+      name: org1-deploy-k8s-builder-job
+    spec:
+      restartPolicy: "Never"
+      containers:
+        - name: main
+          image: ghcr.io/hyperledgendary/fabric-builder-k8s
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - "mkdir -p /mnt/fabric-org1/fabric/external_builders && cp -rv /opt/hyperledger/k8s_builder /mnt/fabric-org1/fabric/external_builders/k8s_builder"
+          volumeMounts:
+            - name: fabric-org1-volume
+              mountPath: /mnt/fabric-org1
+      volumes:
+        - name: fabric-org1-volume
+          persistentVolumeClaim:
+            claimName: fabric-org1

--- a/config/jobs/org2-deploy-builder-job.yaml
+++ b/config/jobs/org2-deploy-builder-job.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: org2-deploy-k8s-builder-job
+spec:
+  backoffLimit: 0
+  completions: 1
+  template:
+    metadata:
+      name: org2-deploy-k8s-builder-job
+    spec:
+      restartPolicy: "Never"
+      containers:
+        - name: main
+          image: ghcr.io/hyperledgendary/fabric-builder-k8s
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - "mkdir -p /mnt/fabric-org2/fabric/external_builders && cp -rv /opt/hyperledger/k8s_builder /mnt/fabric-org2/fabric/external_builders/k8s_builder"
+          volumeMounts:
+            - name: fabric-org2-volume
+              mountPath: /mnt/fabric-org2
+      volumes:
+        - name: fabric-org2-volume
+          persistentVolumeClaim:
+            claimName: fabric-org2

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - role.yaml
+  - rolebinding.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ccaas-role
+rules:
+  - apiGroups:
+      - ""
+      - apps
+      - autoscaling
+      - batch
+      - extensions
+      - policy
+      - rbac.authorization.k8s.io
+    resources:
+      - pods
+      - componentstatuses
+      - configmaps
+      - daemonsets
+      - deployments
+      - events
+      - endpoints
+      - horizontalpodautoscalers
+      - ingress
+      - jobs
+      - limitranges
+      - namespaces
+      - nodes
+      - pods
+      - persistentvolumes
+      - persistentvolumeclaims
+      - resourcequotas
+      - replicasets
+      - replicationcontrollers
+      - serviceaccounts
+      - services
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/config/rbac/rolebinding.yaml
+++ b/config/rbac/rolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ccaas-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ccaas-role
+subjects:
+  - namespace: test-network
+    kind: ServiceAccount
+    name: default

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledgendary/fabric-builder-k8s
 
-go 1.16
+go 1.17
 
 require (
 	github.com/onsi/ginkgo/v2 v2.1.3
@@ -9,4 +9,34 @@ require (
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
+	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/klog/v2 v2.30.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
+	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
+	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -19,9 +19,11 @@ require (
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/internal/builder/run.go
+++ b/internal/builder/run.go
@@ -7,14 +7,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 	"os"
 	"path/filepath"
+	"sigs.k8s.io/yaml"
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 // chaincode represents the chaincode.json file that is supplied by Fabric in
@@ -39,6 +42,20 @@ type Run struct {
 	RunMetadataDirectory string
 }
 
+// TODO: read these from the input scope / json / CLI params / env / etc.
+const (
+	Namespace = "test-network"
+	PeerName = "peer1"
+	ChaincodeName = "asset-transfer-basic"
+	ChaincodeServerAddress = "0.0.0.0:9999"
+
+	// todo: generate the "ApplicationName" for the chaincode endpoint
+	ApplicationName = "org1" + PeerName + "-cc-" + ChaincodeName
+
+	// todo: run locally or run in the cluster with the same client spec
+	RunInCluster = true
+)
+
 func (r *Run) Run() error {
 	imageJsonPath := filepath.Join(r.BuildOutputDirectory, "/image.json")
 	chaincodeJsonPath := filepath.Join(r.RunMetadataDirectory, "/chaincode.json")
@@ -60,7 +77,7 @@ func (r *Run) Run() error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stdout, "Image name: %s\nImage tag: %s\n", imageData.Name, imageData.Tag)
+	fmt.Fprintf(os.Stdout, "Image ApplicationName: %s\nImage tag: %s\n", imageData.Name, imageData.Tag)
 
 	// Read the chaincode.json file
 	fmt.Println("Reading chaincode.json...")
@@ -80,54 +97,74 @@ func (r *Run) Run() error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stdout, "Chaincode ID: %s", chaincodeData.ChaincodeID)
+	fmt.Printf("Chaincode ID: %s\n", chaincodeData.ChaincodeID)
 
-	// creates the in-cluster config
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		panic(err.Error())
+	// todo: find a clientset constructor that will read from either the local .kube/config or the in-cluster service account
+	var config *rest.Config
+
+	if RunInCluster {
+		// creates an in-cluster kube config
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			panic(err.Error())
+		}
+
+	} else {
+		// creates an out of cluster kube config
+		kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "config")
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			panic(err.Error())
+		}
 	}
+
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		panic(err.Error())
 	}
+
 	// TODO use namespace from env var instead of "test-network"
-	deploymentsClient := clientset.AppsV1().Deployments("test-network")
+	deploymentsClient := clientset.AppsV1().Deployments(Namespace)
 
 	// TODO read in a deployment YAML if specified?
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			// TODO unique name!
-			Name: "chaincode-deployment",
+			Name: ApplicationName,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: int32Ptr(2),
-			// TODO labels?
+			Replicas: int32Ptr(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": "demo",
+					"app": ApplicationName,
 				},
 			},
-			// TODO??
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": "demo",
+						"app": ApplicationName,
 					},
 				},
 				Spec: apiv1.PodSpec{
 					Containers: []apiv1.Container{
 						{
-							Name: "chaincode",
-							// TODO use imageData!
-							Image: "nginx:1.12",
-							// TODO ports, env, etc.
+							Name: "main",
+							Image: imageData.Name + ":" + imageData.Tag,
+							Env: []apiv1.EnvVar{
+								{
+									Name: "CHAINCODE_SERVER_ADDRESS",
+									Value: ChaincodeServerAddress,
+								},
+								{
+									Name: "CHAINCODE_ID",
+									Value: chaincodeData.ChaincodeID,
+								},
+							},
 							Ports: []apiv1.ContainerPort{
 								{
-									Name:          "http",
+									Name:          "chaincode",
 									Protocol:      apiv1.ProtocolTCP,
-									ContainerPort: 80,
+									ContainerPort: 9999,
 								},
 							},
 						},
@@ -138,12 +175,49 @@ func (r *Run) Run() error {
 	}
 
 	// Create Deployment
-	fmt.Println("Creating deployment...")
-	result, err := deploymentsClient.Create(context.TODO(), deployment, metav1.CreateOptions{})
+	deploymentYaml, _ := yaml.Marshal(deployment)
+	fmt.Printf("Creating deployment %s:\n", ApplicationName)
+	fmt.Printf("%s\n", deploymentYaml)
+
+	deployment, err = deploymentsClient.Create(context.TODO(), deployment, metav1.CreateOptions{})
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Created deployment %q.\n", result.GetObjectMeta().GetName())
+
+	fmt.Printf("Created deployment %q.\n", deployment.GetObjectMeta().GetName())
+
+
+	// Create a Service to expose the chaincode endpoint to the peer
+	servicesClient := clientset.CoreV1().Services(Namespace)
+
+	service := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ApplicationName,
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{
+				"app": ApplicationName,
+			},
+			Ports: []apiv1.ServicePort{
+				{
+					Name: "chaincode",
+					Port: 9999,
+					Protocol: apiv1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	serviceYaml, _ := yaml.Marshal(service)
+	fmt.Printf("Creating service %s:\n", ApplicationName)
+	fmt.Printf("%s\n", serviceYaml)
+
+	service, err = servicesClient.Create(context.TODO(), service, metav1.CreateOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	fmt.Printf("Created service %q.\n", service.GetObjectMeta().GetName())
 
 	return nil
 }


### PR DESCRIPTION
This PR sets up a Service and Deployment similar to test-network-k8s.

It still needs some work...  

- How will we pass in the input scope for chaincode name, peer name, etc.?   Will these arrive in the incoming env, as passthroughs set in the core yaml builder config?

- There's a local config option `RunInCluster=false` to run the builder `run` target on a local dev machine using the ~/.kube/config 

- Getting the k8s builders into the peer's container will be a real pain.  Here are some ideas: 

1.  run a one-time k8s job that copies the builders into a PV / file share from the builder image.  (👎 )
2. bundle the k8s builders into the peer container (👎 👎 )
3. Use an init container for the peer and copy to/from the builder container into the peer pod (👎 👎 👎 )
4. Something else .... 💯 