### PR TITLE
Update run to correct number of replicas

### DIFF
--- a/internal/builder/run.go
+++ b/internal/builder/run.go
@@ -132,7 +132,7 @@ func (r *Run) Run() error {
 			Name: applicationName,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: int32Ptr(2),
+			Replicas: int32Ptr(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": applicationName,


### PR DESCRIPTION
The peer only wants to start the chaincode once but gets two connections due to “Replicas” being set to 2, which causes an error in the peer log

Signed-off-by: James Taylor <jamest@uk.ibm.com>