### PR TITLE
Rename FABRIC_CHAINCODE_NAMESPACE variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Status: it _should_ just about work now but there are a few issues to iron out (
 
 The k8s builder can be run in cluster using the `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` environment variables, or it can connect using a `KUBECONFIG_PATH` environment variable.
 
-An optional `FABRIC_CHAINCODE_NAMESPACE` can be used to specify the namespace to deploy chaincode to.
+An optional `FABRIC_K8S_BUILDER_NAMESPACE` can be used to specify the namespace to deploy chaincode to.
 
 A `CORE_PEER_ID` environment variable is also currently required.
 
@@ -28,7 +28,7 @@ External builders are configured in the `core.yaml` file, for example:
       path: /opt/hyperledger/k8s_builder
       propagateEnvironment:
         - CORE_PEER_ID
-        - FABRIC_CHAINCODE_NAMESPACE
+        - FABRIC_K8S_BUILDER_NAMESPACE
         - KUBERNETES_SERVICE_HOST
         - KUBERNETES_SERVICE_PORT
 ```

--- a/internal/util/env.go
+++ b/internal/util/env.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	ChaincodeNamespaceVariable = "FABRIC_CHAINCODE_NAMESPACE"
+	builderVariablePrefix      = "FABRIC_K8S_BUILDER_"
+	ChaincodeNamespaceVariable = builderVariablePrefix + "NAMESPACE"
 	KubeconfigPathVariable     = "KUBECONFIG_PATH"
 	PeerIdVariable             = "CORE_PEER_ID"
 )


### PR DESCRIPTION
Follow the convention of the CCaaS builder which uses a `CHAINCODE_AS_A_SERVICE_BUILDER_` prefix to make it more obvious what the environment variable relates to

Signed-off-by: James Taylor <jamest@uk.ibm.com>