### PR TITLE
Simplify logger prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ External builders are configured in the `core.yaml` file, for example:
       path: /opt/hyperledger/k8s_builder
       propagateEnvironment:
         - CORE_PEER_ID
+        - FABRIC_K8S_BUILDER_DEBUG
         - FABRIC_K8S_BUILDER_NAMESPACE
         - KUBERNETES_SERVICE_HOST
         - KUBERNETES_SERVICE_PORT

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -41,20 +41,19 @@ func (nl *nilLogger) Println(v ...interface{}) {
 }
 
 const (
-	prefix = "fabric-builder-k8s"
-	flags  = log.LUTC | log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile | log.Lmsgprefix
+	flags = 0
 )
 
 func New(ctx context.Context) *CmdLogger {
 	cmd, _ := CmdFromContext(ctx)
 	pid, _ := PidFromContext(ctx)
 
-	infoPrefix := fmt.Sprintf("%s: %s [%v]: ", prefix, cmd, pid)
+	infoPrefix := fmt.Sprintf("%s [%v]: ", cmd, pid)
 	infoLogger := log.New(os.Stderr, infoPrefix, flags)
 
 	var debugLogger minimalLogger
 	if DebugFromContext(ctx) {
-		debugPrefix := fmt.Sprintf("%s [DEBUG]: %s [%v]: ", prefix, cmd, pid)
+		debugPrefix := fmt.Sprintf("%s [%v] DEBUG: ", cmd, pid)
 		debugLogger = log.New(os.Stderr, debugPrefix, flags)
 	} else {
 		debugLogger = &nilLogger{}


### PR DESCRIPTION
The peer logging already includes UTC timestamp and the builder name, e.g.

```
2022-06-14 08:44:40.442 UTC 0243 INFO [chaincode.externalbuilder.k8s_builder] waitForExit -> 2022/06/14 08:44:40.442618 log.go:122: fabric-builder-k8s : /var/hyperledger/fabric/external_builders/k8s_builder/bin/release [35]: Release output directory: /tmp/fabric-conga-nft-contract-56c554c330cf883d7f0cf21521aba5abce1159513e708bcf3fcfbb2e27ef92ad2871683330/release command=release
```

Signed-off-by: James Taylor <jamest@uk.ibm.com>