### PR TITLE
Read chaincode.json from the correct directory

### DIFF
--- a/internal/builder/run.go
+++ b/internal/builder/run.go
@@ -30,7 +30,7 @@ func (r *Run) Run(ctx context.Context) error {
 		return err
 	}
 
-	chaincodeData, err := util.ReadChaincodeJson(logger, r.BuildOutputDirectory)
+	chaincodeData, err := util.ReadChaincodeJson(logger, r.RunMetadataDirectory)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The previous commit broke the run binary by trying to read chaincode.json in the build output directory, instead of the run metadata directory

```
2022-06-20 09:05:10.059 UTC 063c INFO [chaincode.externalbuilder.k8s_builder] waitForExit -> /var/hyperledger/fabric/external_builders/k8s_builder/bin/run [53]: Error running chaincode: unable to read /var/hyperledger/fabric/data/org1-peer1.org1.example.com/externalbuilder/builds/conga-nft-contract-5361d5fdb30a8046e37d7db106471f2fed13bacafe85b93b9b39e8bdf00546b0/bld/chaincode.json: open /var/hyperledger/fabric/data/org1-peer1.org1.example.com/externalbuilder/builds/conga-nft-contract-5361d5fdb30a8046e37d7db106471f2fed13bacafe85b93b9b39e8bdf00546b0/bld/chaincode.json: no such file or directory command=run
```

Signed-off-by: James Taylor <jamest@uk.ibm.com>